### PR TITLE
Disable dropdown redirect to scan when on non-mobile

### DIFF
--- a/templates/views/index.pug
+++ b/templates/views/index.pug
@@ -112,7 +112,7 @@ head
                       path(d='m256 60v40h-40v-40zm-40 235v57h40v-57zm120 217v-40h-40v-40h-40v80zm80-297h-120v40h120zm0 80h56v-40h-56zm0 57v40h96v-97h-40v57zm-120-352h-40v60h40zm-40 180h40v-80h-40v40h-40v115h40zm-256 35v80h40v-40h60v-40zm296 80v-40h-40v40zm80 40h40v-40h-40zm96-80h40v-40h-40zm-136 40h-40v57h-40v40h80zm-120 137h40v-40h-40zm120-40v40h80v-40zm120 80v-40h-40v40zm56 40v-40h-56v40zm-136 0h40v-40h-40zm-196-257v-40h-40v40h-40v40h116v-40zm0-75h-180v-180h180zm-40-140h-100v100h100zm-30 30h-40v40h40zm402-70v180h-180v-180zm-40 40h-100v100h100zm-30 30h-40v40h40zm-442 262h180v180h-180zm40 140h100v-100h-100zm30-30h40v-40h-40zm0 0')
                     | Device Code
                 #desktop-notice
-                  a#nav-non-mobile.dropdown-item(href='#')
+                  a#nav-non-mobile.dropdown-item(class="disabled")
                     i.fe.fe-smartphone.mr-2
                     | Please visit on a smartphone to access functions
                 #registration-notice.d-none

--- a/templates/views/index.pug
+++ b/templates/views/index.pug
@@ -112,7 +112,7 @@ head
                       path(d='m256 60v40h-40v-40zm-40 235v57h40v-57zm120 217v-40h-40v-40h-40v80zm80-297h-120v40h120zm0 80h56v-40h-56zm0 57v40h96v-97h-40v57zm-120-352h-40v60h40zm-40 180h40v-80h-40v40h-40v115h40zm-256 35v80h40v-40h60v-40zm296 80v-40h-40v40zm80 40h40v-40h-40zm96-80h40v-40h-40zm-136 40h-40v57h-40v40h80zm-120 137h40v-40h-40zm120-40v40h80v-40zm120 80v-40h-40v40zm56 40v-40h-56v40zm-136 0h40v-40h-40zm-196-257v-40h-40v40h-40v40h116v-40zm0-75h-180v-180h180zm-40-140h-100v100h100zm-30 30h-40v40h40zm402-70v180h-180v-180zm-40 40h-100v100h100zm-30 30h-40v40h40zm-442 262h180v180h-180zm40 140h100v-100h-100zm30-30h40v-40h-40zm0 0')
                     | Device Code
                 #desktop-notice
-                  a#nav-scan.dropdown-item(href='#')
+                  a#nav-non-mobile.dropdown-item(href='#')
                     i.fe.fe-smartphone.mr-2
                     | Please visit on a smartphone to access functions
                 #registration-notice.d-none


### PR DESCRIPTION
# Summary
On desktop, the "Please visit on a smartphone to access functions" dropdown item is clickable and redirects the user to the scan page

I renamed the id and made it appear as disabled

# Test Plan
- View as non-mobile device, click on the dropdown
  - The first item should not be clickable 
