### PR TITLE
Testing Facilities Pug Page -- Replace Healthcare Q&A Tab and Link Footer's Testing Facilities 

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "build": "node build.js",
     "build:dev": "RUNTIME_API_HOST='https://zerobase-api-stage.herokuapp.com' RUNTIME_ENV=dev node build.js",
     "start:dev": "RUNTIME_ENV=dev node devServer.js",
-    "serve": "http-server ./public"
+    "serve": "http-server ./public", 
+    "start": "node devServer.js"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^2.24.0",

--- a/src/templates/navigation/primary.pug
+++ b/src/templates/navigation/primary.pug
@@ -23,7 +23,7 @@ nav#navbar-primary.navbar.navbar-expand-lg.navbar-light.navbar-primary
               | Business or Public Location
             a.dropdown-item(href='#tabs-healthcare', data-toggle='tab')
               i.fe.fe-thermometer.mr-2
-              | Healthcare
+              | Testing Facility
             a.dropdown-item(href='#tabs-community-officials', data-toggle='tab')
               i.fe.fe-shield.mr-2
               | Community Officials

--- a/src/templates/pages/testingsite.pug
+++ b/src/templates/pages/testingsite.pug
@@ -1,0 +1,37 @@
+.content
+  .container(style='padding:0;')
+    .card.card-lg
+      .card-body
+        .markdown
+          .d-flex
+          h2 Zerobase for Testing Facilities and Healthcare Providers
+
+          a.btn.btn-primary(href='#', id="register-healthcare")
+            i.fe.fe-check-square.mr-2
+            | Generate and Print QR
+
+
+          p
+            | <br/>
+            |Zerobase is a free, HIPAA/GDPR-compliant contact tracing platform that helps healthcare providers, local officials, and individuals contain and eliminate COVID-19.
+
+          p Providers who administer COVID-19 tests can deploy Zerobase with nothing more than paper printouts. Because of this, Zerobase can be used at any freestanding, mobile, and temporary testing site.
+
+          p Our contact tracing platform monitors the spread of the virus through a community and can provide individualized risk exposure scores, allowing providers to deploy scarce testing and protective resources most efficiently.
+
+          p Unlike other contact tracing mechanisms developed so far, Zerobase does not track GPS locations, require downloading an app, or necessitate installing intrusive technology.
+
+          h2 Here’s how it works:
+          ol
+            li Upon intake, each patient tested for COVID-19 is given a sheet of paper with a Zerobase QR code on it to scan. Each code sheet is unique and anonymous. Batches of code sheets can be printed and used at testing centers or distributed to mobile or temporary sites.
+            li Using the patient’s trace history, Zerobase’s technology anonymously analyzes community networks of interaction to calculate a risk score for the patient based on their check-in history.
+            li Tracing and test results will be combined to identify individuals in a community who visited the same places as the patient around the same time.
+            li Public health officials can then notify individuals who are registered for contact who may have been exposed and advise them to self-quarantine or get tested, even before they exhibit symptoms.
+
+          p Our team will work closely with you to ensure a smooth rollout in your facilities. Zerobase is designed to support our vital healthcare users and help them stay safe as they provide the critical emergency care that our communities depend on.
+
+          h2 How do I contact Zerobase?
+          p
+            | You can always contact us at        
+            a(href="mailto:info@zerobase.io") info@zerobase.io
+            |.

--- a/src/templates/views/index.pug
+++ b/src/templates/views/index.pug
@@ -59,7 +59,7 @@ body
           #tabs-businesses.tab-pane
             include ../pages/businesses
           #tabs-healthcare.tab-pane
-            include ../pages/healthcare
+            include ../pages/testingsite
           #tabs-community-officials.tab-pane
             include ../pages/community
           #tabs-privacy.tab-pane


### PR DESCRIPTION
adding testing facilities and healthcare providers page to replace Healthcare and to link footer's Testing Facility linking to previous Healthcare tab

Content based on: 
https://docs.google.com/document/d/1GNUA53X3CHMatNnZqX66_NfVxFYxeG9e6zYvxnpL7MU/edit

Resolves: 
Row 19 in airtable 
https://airtable.com/tblc5dSKzb7NvO0wR/viwYPsCfvfnmJRCVz?blocks=hide