### PR TITLE
fixed hero images, general styles cleanup

### DIFF
--- a/public/overrides.css
+++ b/public/overrides.css
@@ -6,6 +6,22 @@
   .iti__flag {background-image: url("/vendor/intl-tel-input/img/flags@2x.png");}
 }
 
+/* Hero Image -------------------------*/
+
+.hero-img-height {
+  height: 20rem;
+  background: #e9ecef;
+}
+.hero-img-cover {
+  background: no-repeat center;
+  background-size: cover;
+}
+@media only screen and (max-device-width:750px) {
+  .hero-img-height {
+    height: 13rem;
+  }
+}
+
 
 /* Nav Scroll -------------------------*/
 .scroll {

--- a/src/templates/navigation/footer.pug
+++ b/src/templates/navigation/footer.pug
@@ -44,7 +44,7 @@ footer#footer-main.position-relative
             li
               router-link(to='/individual') Individuals
             li
-              router-link(to='/businesses') Locations
+              router-link(to='/businesses') Businesses & Locations
             li
               router-link(to='/healthcare') Testing Facilities
             li

--- a/src/templates/navigation/primary.pug
+++ b/src/templates/navigation/primary.pug
@@ -5,10 +5,6 @@ nav#navbar-primary.navbar.navbar-expand-lg.navbar-light.navbar-primary
       ul.nav.nav-tabs(data-toggle='tabs')
         li.nav-item
           router-link.nav-link(to='/') Home
-        li.nav-item
-          router-link.nav-link(to='/about') About
-        li.nav-item
-          router-link.nav-link(to='/privacy') Privacy
         li.nav-item.dropdown
           a.nav-link.dropdown-toggle(data-toggle='dropdown', href='#', role='button', aria-haspopup='true', aria-expanded='false') Uses
           .dropdown-menu
@@ -16,17 +12,7 @@ nav#navbar-primary.navbar.navbar-expand-lg.navbar-light.navbar-primary
             router-link.dropdown-item(to='/community') Community Officials
             router-link.dropdown-item(to='/businesses') Business or Public Locations
             router-link.dropdown-item(to='/testing') Healthcare Testing Sites
-
-            //-.dropdown-divider
-                router-link.dropdown-item(to='/individual')
-                  i.fe.fe-user.mr-2
-                  | Individual
-                router-link.dropdown-item(to='/businesses')
-                  i.fe.fe-home.mr-2
-                  | Business or Public Location
-                router-link.dropdown-item(to='/healthcare')
-                  i.fe.fe-thermometer.mr-2
-                  | Healthcare
-                router-link.dropdown-item(to='/community')
-                  i.fe.fe-shield.mr-2
-                  | Community
+        li.nav-item
+          router-link.nav-link(to='/about') About
+        li.nav-item
+          router-link.nav-link(to='/privacy') Privacy

--- a/src/templates/pages/about_us.pug
+++ b/src/templates/pages/about_us.pug
@@ -1,28 +1,23 @@
 .content.m-0.p-0.w-100
-  .container-fluid.w-100.p-0.mb-8
+  .container-fluid.w-100.p-0.mb-2.mb-md-6
     .row
        .col-12
           .card.mb-0
-              img.card-img(src='/assets/img/info/ZBHero_Mission.jpg', alt='Card image')
-              .card-img-overlay.text-center.d-flex.align-items-center
-                .container
-                  //-h1.text-white Everything You Need To Know About Zerobase
-
+            .hero-img-height.hero-img-cover(style='background-image: url(/assets/img/info/ZBHero_Mission.jpg); filter:brightness(70%)', alt='Our Mission')
   .container
     .row.m-2
       .col-12(style="margin: 0 auto;")
         .card(style="border:none; background-color:").shadow-none
           .card-body.shadow-none
             .row.align-items-center
-              .col-lg-12.d-flex.justify-content-center
+              .col-lg-12.d-flex.justify-content-center.text-center
                 h1 Everything You Need To Know About
 
             .row.align-items-center
               .col-lg-12.d-flex.justify-content-center
                 img.w-50(src="/assets/img/info/ZerobaseLogo_light.png")
 
-
-    .row.m-4.mt-7.mb-5
+    .row.m-4.mb-6
         .col-lg-6.col-12.pr-lg-5
           p.h1.lh-180.mb-3
             | Zerobase is a free, privacy-first contact tracing platform that empowers both individuals and local officials to stop the spread of COVID-19.
@@ -32,19 +27,11 @@
           p.lead.lh-180
             | Zerobase enables local communities to establish their first line of defense against COVID-19 outbreaks in a way that is private, easy to use, and helps to alleviate the manual issues involved in contact tracing and individualized testing.
           a.btn.btn-outline-dark.font-weight-normal(href='https://www.who.int/features/qa/contact-tracing/en/' role="button" style="border-color: #65C6E1; color:#65C6E1") More about contact tracing
-    br
-    br
-
 
     .row.m-4.p-5.mt-5.border-top.border-secondary.pb-4.pt-4
         .col-12.col-lg-12.pr-lg-5.mt-6
             p.h1.lh-180.mb-3.font-weight-normal
                | We built Zerobase to help real people
-
-
-
-
-
     .row
         .col-lg-4.col-12.text-center.mb-2
            img.w-50.mt-3.mb-3.card-img(src='/assets/img/earth.png', alt='Card image', style="opacity:0.7; transform:rotate(15deg)")

--- a/src/templates/pages/business_landing.pug
+++ b/src/templates/pages/business_landing.pug
@@ -1,21 +1,19 @@
 .content.m-0.p-0.w-100
-  .container-fluid.w-100.p-0.mb-8
+  .container-fluid.w-100.p-0.mb-2.mb-md-6
     .row
        .col-12
           .card.mb-0
-            img.card-img(src='/assets/img/info/ZB_containers_location.jpg', alt='Card image' style="filter:brightness(70%)")
-            //-.card-img-overlay.text-center.d-flex.align-items-center
-              .container
-                 h1.text-white(style="font-size:300%;") Businesses and Public Locations
+            .hero-img-height.hero-img-cover(style='background-image: url(/assets/img/info/ZB_containers_location.jpg); filter:brightness(70%)')
+  
   .container
-    .media-container-row
+    .row.m-2.mb-6
       .title.col-12.col-md-8
         h2.align-center.pb-3.mbr-fonts-style.display-2
           | Businesses and Public Locations
         h3.mbr-section-subtitle.align-center.mbr-light.mbr-fonts-style.display-5
           | Lead your community in the fight against COVID-19.
 
-    .row.m-4.mt-7.mb-5
+    .row.m-2.mb-md-5
         .col-lg-6.col-12.pr-lg-5
           p.h1.lh-180.mb-3(style="font-size:36px;")
             | Zerobase is a free, privacy-first contact tracing platform that empowers both individuals and local officials to stop the spread of COVID-19.

--- a/src/templates/pages/community.pug
+++ b/src/templates/pages/community.pug
@@ -1,31 +1,27 @@
 .content.m-0.p-0.w-100
-  .container-fluid.w-100.p-0.mb-8
+  .container-fluid.w-100.p-0.mb-2.mb-md-6
     .row
        .col-12
           .card.mb-0
-            img.card-img(src='/assets/img/info/ZB_containers_community.jpg', alt='Card image' style="filter:brightness(70%)")
-            //-.card-img-overlay.text-center.d-flex.align-items-center
-              .container
-                 h1.text-white(style="font-size:300%;") Businesses and Public Locations
+            .hero-img-height.hero-img-cover(style='background-image: url(/assets/img/info/ZB_containers_community.jpg); filter:brightness(70%)')
+  
   .container
-    .media-container-row
+    .row.m-2.mb-6
       .title.col-12.col-md-8
         h2.align-center.pb-3.mbr-fonts-style.display-2
           | Community and Public Officials
 
         h3.mbr-section-subtitle.align-center.mbr-light.mbr-fonts-style.display-5
           | Zerobase is a free, privacy-first contact tracing platform that empowers
-
-        h3.mbr-section-subtitle.align-center.mbr-light.mbr-fonts-style.display-5
           | both individuals and local officials to stop the spread of COVID-19.
 
-    .row.m-2.mt-7.mb-5
+    .row.m-2.mb-md-5
         .col-lg-8.col-12.pr-lg-5
           p.h1.mb-3(style="font-size:36px;")
             | Why should you partner with Zerobase?
 
     .container
-      .media-container-row.mt-6
+      .media-container-row.mt-md-5
         .col-lg-12.col-12
           .media-container-row
             .media-content
@@ -39,7 +35,7 @@
                   |     The sooner you partner with Zerobase, the stronger your check-in data repository becomes, allowing you to make each test administered within your community exponentially more powerful, especially in places with critical public health resource limitations.
 
 
-      .media-container-row.mt-6
+      .media-container-row.mt-md-5
         .col-lg-12.col-12
           .media-container-row
             .media-content

--- a/src/templates/pages/home.pug
+++ b/src/templates/pages/home.pug
@@ -1,4 +1,4 @@
-.content.pt-0.pt-md-4
+.content.pt-0
   .container-fluid.p-0
     .row(style='padding:0;')
       .col-12

--- a/src/templates/pages/individuals_landing.pug
+++ b/src/templates/pages/individuals_landing.pug
@@ -1,21 +1,19 @@
 .content.m-0.p-0.w-100
-  .container-fluid.w-100.p-0.mb-8
+  .container-fluid.w-100.p-0.mb-md-6
     .row
        .col-12
           .card.mb-0
-            img.card-img(src='/assets/img/info/ZB_containers_testing.jpg', alt='Card image' style="filter:brightness(70%)")
-            //-.card-img-overlay.text-center.d-flex.align-items-center
-              .container
-                 h1.text-white(style="font-size:300%;") Businesses and Public Locations
+            .hero-img-height.hero-img-cover(style='background-image: url(/assets/img/info/ZB_containers_testing.jpg); filter:brightness(70%)')
+  
   .container
-    .media-container-row
+    .row.m-2.mb-6
       .title.col-12.col-md-8
         h2.align-center.pb-3.mbr-fonts-style.display-2
           | Individuals
         h3.mbr-section-subtitle.align-center.mbr-light.mbr-fonts-style.display-5
           | Support your community in the fight against COVID-19.
 
-    .row.m-4.mt-7.mb-5
+    .row.m-2.mb-md-5
         .col-lg-6.col-12.pr-lg-5
           p.h1.lh-180.mb-3(style="font-size:30px;")
             | Zerobase is a free, privacy-first contact tracing platform that empowers you to help your community stop the spread of COVID-19.

--- a/src/templates/pages/privacy_landing.pug
+++ b/src/templates/pages/privacy_landing.pug
@@ -1,17 +1,15 @@
-.content.pb-0.mb-0
-  .container-fluid.w-100.p-0.mb-8
+.content.pt-0.pb-0.mb-0
+  .container-fluid.w-100.p-0.mb-md-6
       .row
          .col-12
             .card.mb-0
-                img.card-img(src='/assets/img/info/ZBHero_privacy.jpg', alt='Card image')
-                .card-img-overlay.text-center.d-flex.align-items-center
-                  .container
+              .hero-img-height.hero-img-cover(style='background-image: url(/assets/img/info/ZBHero_privacy.jpg)')
   .container
-      .row.m-4.mb-7
+      .row.m-4.mb-md-6
           .col-lg-8.col-12.pr-lg-5
             p.h1.mb-5(style="color:#1B2935; font-size:400%")
                 | Privacy First
-      .row.m-4.mb-5
+      .row.m-4.mb-md-5
           .col-lg-6.col-12.pr-lg-5
             p.h1.lh-180.mb-3(style="font-size:24px;")
               | Zerobase is designed from the ground up to put your privacy first.

--- a/src/templates/pages/testingsite_landing.pug
+++ b/src/templates/pages/testingsite_landing.pug
@@ -1,29 +1,26 @@
 .content.m-0.p-0.w-100
-  .container-fluid.w-100.p-0.mb-8
+  .container-fluid.w-100.p-0.mb-2.mb-md-6
     .row
        .col-12
           .card.mb-0
-            img.card-img(src='/assets/img/info/ZB_containers_testing.jpg', alt='Card image' style="filter:brightness(70%)")
-            //-.card-img-overlay.text-center.d-flex.align-items-center
-              .container
-                 h1.text-white(style="font-size:300%;") Businesses and Public Locations
+            .hero-img-height.hero-img-cover(style='background-image: url(/assets/img/info/ZB_containers_testing.jpg); filter:brightness(70%)', alt='Card image')
   .container
-    .media-container-row
-      .title.col-12.col-md-8
+    .row.m-2.mb-6
+      .title.col-12.col-md-6
         h2.align-center.pb-3.mbr-fonts-style.display-2
           | Healthcare and Testing Sites
         h3.mbr-section-subtitle.align-center.mbr-light.mbr-fonts-style.display-5
           | Support your community in the fight against COVID-19.
 
-    .row.m-4.mt-7.mb-5
-        .col-lg-6.col-12.pr-lg-5
-          p.h1.lh-180.mb-3(style="font-size:30px;")
-            | Zerobase is a free, HIPAA/GDPR-compliant contact tracing platform that helps healthcare providers, local officials, and individuals contain and eliminate COVID-19.
-        .col-lg-6.col-12
-          p.lead.lh-180(style="font-size:24px;")
-            | Providers who administer COVID-19 tests can deploy Zerobase with nothing more than paper printouts.
-          p.lead.lh-180(style="font-size:24px;")
-            | Because of this, Zerobase can be used at any freestanding, mobile, and temporary testing site.
+    .row.m-2.mb-md-5
+      .col-lg-6.col-12.pr-lg-5
+        p.h1.lh-180.mb-3(style="font-size:30px;")
+          | Zerobase is a free, HIPAA/GDPR-compliant contact tracing platform that helps healthcare providers, local officials, and individuals contain and eliminate COVID-19.
+      .col-lg-6.col-12
+        p.lead.lh-180(style="font-size:24px;")
+          | Providers who administer COVID-19 tests can deploy Zerobase with nothing more than paper printouts.
+        p.lead.lh-180(style="font-size:24px;")
+          | Because of this, Zerobase can be used at any freestanding, mobile, and temporary testing site.
 
     .container
       .media-container-row.mt-6


### PR DESCRIPTION
Hero images for informational pages should use the following pattern:

` .hero-img-height.hero-img-cover(style='background-image: url(/assets/img/info/ZB_containers_location.jpg); filter:brightness(70%)')`

This Resolves #148 and also cleans up styles for mobile and the strange spacing.

Too much generous usage of .mt-6 and .mb-6. Should copy patterns where possible and provide styles for mobile first .mt-md-6