### PR TITLE
link to signup page not modal

### DIFF
--- a/src/templates/pages/business_landing.pug
+++ b/src/templates/pages/business_landing.pug
@@ -79,9 +79,8 @@
                    |Zerobase is free, it’s ready, and it saves lives.
 
             .col-lg-4.col-12.align-middle.mt-6
-
-                a.btn.btn-primary.btn-lg.align-middle(href='#', id="register-business")
-                    | Enroll in under a minute
+                router-link.btn.btn-primary.btn-lg.align-middle(to='/business/register') 
+                  | Enroll in under a minute
 
 
 

--- a/src/templates/pages/testingsite_landing.pug
+++ b/src/templates/pages/testingsite_landing.pug
@@ -106,8 +106,8 @@
 
             .col-lg-4.col-12.align-middle.mt-6
 
-                a.btn.btn-primary.btn-lg.align-middle(href='#', id="register-healthcare")
-                    | Register your site
+                router-link.btn.btn-primary.btn-lg.align-middle(to='/healthcare/register') 
+                  | Register your site
 
 
 


### PR DESCRIPTION
Resolves #201 

Clicking on call to action on business and healthcare information pages link to standalone signup page, deprecates modal