### PR TITLE
undefined deviceID, updates API to handle null states

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -54,9 +54,10 @@ const controller = (() => ({
       contentType: 'application/json',
       processData: false,
       type: 'POST',
-      success: (data: { id: object }) => {
-        console.log('Device ID Created:', data.id.value);
-        localStorage.setItem('dvid', String(data.id.value));
+      success: (data: { id: string }) => {
+        console.log(data);
+        console.log('Device ID Created:', data.id);
+        localStorage.setItem('dvid', data.id);
         $('#register-notice-agree').removeClass('btn-loading');
         $('#mobile-functions').removeClass('d-none');
         $('#registration-notice').addClass('d-none');
@@ -84,8 +85,10 @@ const controller = (() => ({
   ) => {
     const dvid = localStorage.getItem('dvid');
     const postData = JSON.stringify({
+      name: '';
       contact: {
         "phone": inputs.phone,
+        "email": '';
       },
       deviceId: dvid
     });
@@ -99,11 +102,12 @@ const controller = (() => ({
       processData: false,
       type: 'POST',
       success: (data: { id: string }) => {
+
         console.log('User ID Created:', data.id);
         $('#notify-warning').addClass('d-none');
         $('#notify-success').removeClass('d-none');
         $(inputs.button_id).removeClass('btn-loading');
-        $(inputs.button_id).attr("disabled", true);
+        $(inputs.button_id).replaceWith('<a class="btn btn-secondary btn-block mt-0" href="/" style="border-radius: 0px 0px 3px 3px;">Continue to Zerobase</a>')
         
       },
       error: err => {
@@ -139,7 +143,6 @@ const controller = (() => ({
 
     } | undefined,
   ) => {
-
 
     const postData = JSON.stringify({
       name: inputs != null ? inputs.org_name : undefined,
@@ -347,15 +350,19 @@ const controller = (() => ({
     cb: () => void,
   ) => {
     const dvid = localStorage.getItem('dvid');
-
     const postData = JSON.stringify({
       scannedId: inputs != null ? inputs.sdvid : undefined,
-      type: 'DEVICE_TO_DEVICE',
+      type: 'DEVICE_TO_SCANNABLE',
+      location: {
+        lat: '',
+        long: '',
+      }
       // fingerprint: inputs != null ? inputs.fingerprint : undefined,
     });
-
+    console.log('Scanning with: '+dvid);
+    console.log(postData);
     const opts: JQuery.AjaxSettings = {
-      url: `${API_HOST}/devices/${dvid}/check-ins`,
+      url: `${API_HOST}/devices/`+dvid+`/check-ins`,
       data: postData,
       cache: false,
       dataType: 'json',

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -354,8 +354,8 @@ const controller = (() => ({
       scannedId: inputs != null ? inputs.sdvid : undefined,
       type: 'DEVICE_TO_SCANNABLE',
       location: {
-        lat: '',
-        long: '',
+        lat: 0,
+        long: 0,
       }
       // fingerprint: inputs != null ? inputs.fingerprint : undefined,
     });

--- a/src/router.ts
+++ b/src/router.ts
@@ -46,9 +46,11 @@ $(() => {
       beforeEnter: (to, from, next) => {
         const sdvid = to.params.pathMatch
         const dvid  = localStorage.getItem('dvid');
+        // fix for people who might have undefined in their localStorage
+        if(dvid === "undefined"){dvid = undefined}
         history.replaceState(null, null, '/');
 
-        if(sdvid){
+        if(sdvid && window.innerWidth < 750){
           if(dvid){
             console.log('Has registered ID on scan');
             $('#modal-scan-notice').modal('show');
@@ -128,7 +130,10 @@ $(() => {
               router.push('/').catch(err => {})
             });
           });
-        }
+        },
+        // beforeDestroy(){
+          
+        // }
       }
     }
   ]

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -49,6 +49,7 @@ const scanning = (() => {
           if (codeAction === 's' && codeSdvid) {
             // @ts-ignore
             sound.play();
+            console.log(code.data);
             window.location.replace(code.data);
             return;
           }


### PR DESCRIPTION
Resolves some misalignment issues with the new API:

1. create originally returned id as an object id:{value: string}, updated to create id:string

2. undefined was originally converted to string and inserted into localstorage. This would later cause an error on scanning since deviceID would be "undefined". This PR first checks if deviceID is currently ==="undefined" if so, assigns a new valid deviceID

3. creating new user and new checkin had null values which conflicts with gremlin setup, we resolve this by passing an empty string as part of the complete object. Subsequent work would include gremlin defining which fields are optional or not and better error responses.
