### PR TITLE
remove semicolon, but this doesnt cause errors

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -88,7 +88,7 @@ const controller = (() => ({
       name: '';
       contact: {
         "phone": inputs.phone,
-        "email": '';
+        "email": ''
       },
       deviceId: dvid
     });


### PR DESCRIPTION
Removes a semicolon from a JSON object in controller.ts, but this shouldn't be causing any recent view errors on staging.zerobase.io?

