### PR TITLE
hotfix since mobile safari isnt 100vh

### DIFF
--- a/src/templates/modal/feedback.pug
+++ b/src/templates/modal/feedback.pug
@@ -1,6 +1,6 @@
 #modal-feedback.modal.modal-blur.fade(tabindex='-1', role='dialog', aria-hidden='true')
   .modal-dialog.modal-dialog-centered.modal-dialog-scrollable(role='document')
-    .modal-content(style="min-height:100vh;")
+    .modal-content(style="min-height:90vh;")
       .modal-header
         h5.modal-title Feedback
         button.close(type='button', data-dismiss='modal', aria-label='Close')

--- a/src/templates/modal/register-notifications.pug
+++ b/src/templates/modal/register-notifications.pug
@@ -1,6 +1,6 @@
 #modal-register-notifications.modal.modal-blur.fade(tabindex='-1', role='dialog', aria-hidden='true')
   .modal-dialog.modal-dialog-centered.modal-dialog-scrollable(role='document')
-    .modal-content(style="min-height:100vh")
+    .modal-content(style="min-height:90vh")
       .modal-header
         h5.modal-title Opt-in for Notifications
         button.close(type='button', data-dismiss='modal', aria-label='Close')


### PR DESCRIPTION
Mobile Safari is badddddd. The bottom tab actually eats into the view height, anything residing below 90vh will be covered. This PR addresses that issue for the scan success/ error screens