### PR TITLE
Removed explicit font size declarations in business_landing, communit…

### DIFF
--- a/src/templates/pages/business_landing.pug
+++ b/src/templates/pages/business_landing.pug
@@ -4,7 +4,7 @@
        .col-12
           .card.mb-0
             .hero-img-height.hero-img-cover-top(style='background-image: url(/assets/img/info/ZB_containers_location.jpg); filter:brightness(70%);', alt='Man putting open sign in window.')
-  
+
   .container
     .row.m-2.mb-6
       .title.col-12.col-md-8
@@ -15,12 +15,12 @@
 
     .row.m-2.mb-md-5
         .col-lg-6.col-12.pr-lg-5
-          p.h1.lh-180.mb-3(style="font-size:36px;")
+          h1.h1.lh-180.mb-3
             | Zerobase is a free, privacy-first contact tracing platform that empowers both individuals and local officials to stop the spread of COVID-19.
         .col-lg-6.col-12
-          p.lead.lh-180(style="font-size:24px;")
+          h2.lead.lh-180
             | Zerobase anonymously monitors the spread of the virus and warns exposed individuals to stay at home and avoid infecting other members of the community.
-          p.lead.lh-180(style="font-size:24px;")
+          h2.lead.lh-180
             | With your help, we can keep the public healthy and businesses open, putting your community back on its feet.
 
     .container
@@ -29,8 +29,9 @@
           .media-container-row
             .media-content
               .mbr-section-text
-                p.mbr-text.mb-0.mbr-fonts-style(style="font-size:24px;")
+                h3.mbr-text.mb-0.mbr-fonts-style
                   strong Unlike other contact tracing mechanisms developed so far,
+                p.mbr-text.mb-0.mbr-fonts-style
                   |     Zerobase doesn't track GPS locations, require downloading an app, or require intrusive technology to be installed in your building. By automatically notifying individuals to stay home if they’ve been exposed, Zerobase takes the burden off you to ensure that your location and employees are safe- without any extra staff.
 
 
@@ -39,8 +40,9 @@
           .media-container-row
             .media-content
               .mbr-section-text
-                p.mbr-text.mb-0.mbr-fonts-style(style="font-size:24px;")
+                h3.mbr-text.mb-0.mbr-fonts-style
                   strong Here’s how it works:
+                p.mbr-text.mb-0.mbr-fonts-style
                   |     Paper printouts with unique Zerobase QR codes are posted at entrances and touchpoints of your location, for example the front door and the cash register. People entering your location scan the code by simply pointing their phone’s camera at the sign – it takes just a few seconds. Zerobase’s tracing technology anonymously analyzes community networks of interaction to identify people who may have been exposed.
 
       .media-container-row.mt-6
@@ -48,8 +50,9 @@
           .media-container-row
             .media-content
               .mbr-section-text
-                p.mbr-text.mb-0.mbr-fonts-style(style="font-size:24px;")
+                h3.mbr-text.mb-0.mbr-fonts-style
                   strong If an individual is exposed to or contracts COVID-19,
+                p.mbr-text.mb-0.mbr-fonts-style
                   |     public health officials can use Zerobase to direct anyone who has been in their presence to self-quarantine and stop the virus from spreading. In this way, Zerobase keeps your employees and your location safe.
 
       .media-container-row.mt-6
@@ -57,7 +60,7 @@
           .media-container-row
             .media-content
               .mbr-section-text
-                p.mbr-text.mb-0.mbr-fonts-style(style="font-size:30px;")
+                h1.mbr-text.mb-0.mbr-fonts-style
                   strong At no point does an individual’s check-in get tracked alongside their identity.
 
       .media-container-row.mt-6
@@ -65,21 +68,22 @@
           .media-container-row
             .media-content
               .mbr-section-text
-                p.mbr-text.mb-0.mbr-fonts-style(style="font-size:24px;")
+                h3.mbr-text.mb-0.mbr-fonts-style
                   strong Zerobase is deployable by businesses and community touchpoints
+                p.mbr-text.mb-0.mbr-fonts-style
                   |     with nothing more than a computer and a printer. Because of this, Zerobase can be deployed everywhere in minutes to be accessible to and instantly usable by all. By joining the Zerobase network of businesses, public locations, and community touchpoints, you are doing your part to end the spread of the virus and revitalize your community.
       br
       br
       .container
         .row.m-4.p-5.mt-5.border-top.border-secondary.pb-4.pt-4
             .col-lg-8.col-12.pr-lg-5.mt-6
-                p.h1.lh-180.mb-3
+                h3.h1.lh-180.mb-3
                    | Lead your community in the fight against COVID-19.
-                p.h2.font-weight-normal
+                h3.h2.font-weight-normal
                    |Zerobase is free, it’s ready, and it saves lives.
 
             .col-lg-4.col-12.align-middle.mt-6
-                router-link.btn.btn-primary.btn-lg.align-middle(to='/business/register', id='register-business') 
+                router-link.btn.btn-primary.btn-lg.align-middle(to='/business/register', id='register-business')
                   | Enroll in under a minute
 
 

--- a/src/templates/pages/community.pug
+++ b/src/templates/pages/community.pug
@@ -4,7 +4,7 @@
        .col-12
           .card.mb-0
             .hero-img-height.hero-img-cover-top(style='background-image: url(/assets/img/info/ZB_containers_community.jpg); filter:brightness(70%)', alt='Woman at podium speaking to audience.')
-  
+
   .container
     .row.m-2.mb-6
       .title.col-12.col-md-8
@@ -17,7 +17,7 @@
 
     .row.m-2.mb-md-5
         .col-lg-8.col-12.pr-lg-5
-          p.h1.mb-3(style="font-size:36px;")
+          h1.h1.mb-3
             | Why should you partner with Zerobase?
 
     .container
@@ -26,12 +26,13 @@
           .media-container-row
             .media-content
               .mbr-section-text
-                p.mbr-text.mb-0.mbr-fonts-style.mb-3(style="font-size:24px; ")
+                h3.mbr-text.mb-0.mbr-fonts-style.mb-3
                   strong Because it’s your community’s first line of defense.
+                p.mbr-text.mb-0.mbr-fonts-style.mb-3
                   |     Zerobase deploys contact tracing across a community in a way that is anonymous, fast, and easy to use. You can allocate your time and resources more efficiently, elevating your community’s ability to contain the virus. We provide you with a powerful way to instantaneously track interactions with exposed individuals without invading their privacy.
-                p.mbr-text.mb-0.mbr-fonts-style.mb-3(style="font-size:24px; ")
+                p.mbr-text.mb-0.mbr-fonts-style.mb-3
                   |     Zerobase empowers you to take action with conviction, such as recommending that an exposed individual self-quarantine or be registered for a COVID-19 test. Zerobase is also an early warning system to alert you when an outbreak begins so that you can avoid a blanket lockdown while quickly and effectively deploying strategic public health resources to the places that need them the most.
-                p.mbr-text.mb-0.mbr-fonts-style.mb-3(style="font-size:24px; ")
+                p.mbr-text.mb-0.mbr-fonts-style.mb-3
                   |     The sooner you partner with Zerobase, the stronger your check-in data repository becomes, allowing you to make each test administered within your community exponentially more powerful, especially in places with critical public health resource limitations.
 
 
@@ -40,8 +41,9 @@
           .media-container-row
             .media-content
               .mbr-section-text
-                p.mbr-text.mb-0.mbr-fonts-style(style="font-size:24px;")
+                h3.mbr-text.mb-0.mbr-fonts-style
                   strong Because contact tracing contains outbreaks.
+                p.mbr-text.mb-0.mbr-fonts-style.mb-3
                   |     Research demonstrates that real-time contact tracing is enough to control an outbreak of COVID-19 in a matter of weeks. If an individual is exposed to COVID-19, contact tracing allows us to pinpoint any number of others who were in the same place – such as a community center – as the exposed individual. Community healthcare providers, with the help of Zerobase, can then provide personalized recommendations to potentially-affected people in order to stop the spread with precision.
 
 
@@ -50,8 +52,9 @@
           .media-container-row
             .media-content
               .mbr-section-text
-                p.mbr-text.mb-0.mbr-fonts-style(style="font-size:24px;")
+                h3.mbr-text.mb-0.mbr-fonts-style
                   strong Because it reduces resurgence.
+                p.mbr-text.mb-0.mbr-fonts-style.mb-3
                   |     Zerobase helps contain the spread of infection and resurgence through automated notifications of an individual’s interactions when they are likely infected. Epidemiologists have found that minimizing the time between symptom onset and isolation is the most critical part of controlling an outbreak. Zerobase detects possible exposure to the virus days before symptoms begin, and can recommend proactive isolation that will prevent a resurgence without resorting to a full lockdown.
 
 
@@ -60,9 +63,9 @@
           .media-container-row
             .media-content
               .mbr-section-text
-                p.mbr-text.mb-0.mbr-fonts-style(style="font-size:30px;")
+                h3.mbr-text.mb-0.mbr-fonts-style
                   strong The best time to implement Zerobase in your community was last week.
-                p.mbr-text.mb-0.mbr-fonts-style(style="font-size:30px;")
+                h3.mbr-text.mb-0.mbr-fonts-style
                   strong The second best time is now.
 
       br

--- a/src/templates/pages/individuals_landing.pug
+++ b/src/templates/pages/individuals_landing.pug
@@ -4,7 +4,7 @@
        .col-12
           .card.mb-0
             .hero-img-height.hero-img-cover-top(style='background-image: url(/assets/img/info/ZB_containers_testing.jpg); filter:brightness(70%)', alt='Nurse with clip board talking to patient.')
-  
+
   .container
     .row.m-2.mb-6
       .title.col-12.col-md-8
@@ -15,38 +15,39 @@
 
     .row.m-2.mb-md-5
         .col-lg-6.col-12.pr-lg-5
-          p.h1.lh-180.mb-3(style="font-size:30px;")
+          h2.h1.lh-180.mb-3
             | Zerobase is a free, privacy-first contact tracing platform that empowers you to help your community stop the spread of COVID-19.
         .col-lg-6.col-12
-          p.lead.lh-180(style="font-size:24px;")
+          h3.lead.lh-180
             | At the core of Zerobase is our QR code network that traces the spread of the virus, even among individuals who aren’t showing symptoms, without GPS tracking or installing an app.
-          p.lead.lh-180(style="font-size:24px;")
+          h3.lead.lh-180
             | By simply scanning a QR code when you walk into a grocery store, a pharmacy, or another community location, you’re helping keep yourself, your family, and your community safe while protecting your privacy.
 
 
   .container.mt-6
      .row.m-4.p-5.mt-5.border-top.border-secondary.pb-4.pt-4
-        .col-12(style="font-size:48px;")
+        .col-12
+         h1.h1.lh-180.mb-3
             strong Here's how it works:
 
      .row.align-middle
         .col-lg-3.col-3.text-center
-            p(style="font-size:76px;")
+            p(style="font-size:60px;")
               strong 1
 
         .col-lg-9.col-9.align-middle.my-auto
-            p.align-middle(style="font-size:24px;")
+            p.align-middle
                 strong Unique Zerobase QR codes
                 |       are posted at the entrances of buildings like grocery stores, restaurants, pharmacies, doctor's offices, and places of worship.
 
 
      .row.align-middle
         .col-lg-3.col-3.text-center
-            p(style="font-size:76px;")
+            p(style="font-size:60px;")
               strong 2
 
         .col-lg-9.col-9.align-middle.my-auto
-            p.align-middle(style="font-size:24px;")
+            p.align-middle
                 | Each time you visit a location,
                 strong      scan the code
                 |       by simply pointing your phone’s camera at the sign – it takes just a few seconds, and no app installation is required. Zerobase never tracks your identity or monitors your GPS location. If you would like to be notified if you may have been exposed to COVID-19, you may voluntarily and securely store your phone number. Any information provided is encrypted and used only to keep you informed.
@@ -54,11 +55,11 @@
 
      .row.align-middle
         .col-lg-3.col-3.text-center
-            p(style="font-size:76px;")
+            p(style="font-size:60px;")
               strong 3
 
         .col-lg-9.col-9.align-middle.my-auto
-            p.align-middle(style="font-size:24px;")
+            p.align-middle
                 | Our tracing technology
                 strong      anonymously links
                 |       community networks of contact to identify people who visited the same place at roughly the same time.
@@ -66,11 +67,11 @@
 
      .row.align-middle
         .col-lg-3.col-3.text-center
-            p(style="font-size:76px;")
+            p(style="font-size:60px;")
               strong 4
 
         .col-lg-9.col-9.align-middle.my-auto
-            p.align-middle(style="font-size:24px;")
+            p.align-middle
                 | If someone is
                 strong      exposed to COVID-19,
                 |       public health officials can use Zerobase to direct community members who might have come into contact with them to self-quarantine and get tested. In this way, Zerobase helps stop the spread of the infection proactively and flatten the curve sooner.
@@ -81,7 +82,7 @@
           .media-container-row
             .media-content
               .mbr-section-text
-                p.mbr-text.mb-0.mbr-fonts-style.text-center(style="font-size:36px;")
+                h3.mbr-text.mb-0.mbr-fonts-style.text-center
                   strong By checking in anonymously to community touchpoints, you’re doing your part to keep your community healthy and safe.
 
 

--- a/src/templates/pages/privacy_landing.pug
+++ b/src/templates/pages/privacy_landing.pug
@@ -7,25 +7,25 @@
   .container
       .row.m-4.mb-md-6
           .col-lg-8.col-12.pr-lg-5
-            p.h1.mb-5(style="color:#1B2935; font-size:400%")
+            h1
                 | Privacy First
       .row.m-4.mb-md-5
           .col-lg-6.col-12.pr-lg-5
-            p.h1.lh-180.mb-3(style="font-size:24px;")
+            h1.lh-180.mb-3
               | Zerobase is designed from the ground up to put your privacy first.
           .col-lg-6.col-12
-            p.lead.lh-180(style="font-size:24px;")
+            p.lead.lh-180
               | Unlike other contact tracing mechanisms developed so far, Zerobase does not track GPS locations or require downloading an application to your phone.
-            p.lead.lh-180(style="font-size:24px;")
+            p.lead.lh-180
               | Instead, our QR network securely and privately traces the spread of COVID-19 throughout a community without tracking your personal identity or your location at all hours of the day.
       .row.m-4.mb-5
             .col-lg-6.col-12.pr-lg-5
-              p.h1.lh-180.mb-3(style="font-size:24px;")
+              h1.lh-180.mb-3
                 | Zerobase was built to help real people.
             .col-lg-6.col-12
-              p.lead.lh-180(style="font-size:24px;")
+              p.lead.lh-180
                 | If you would like to be notified if you may have been exposed to COVID-19, you may voluntarily and securely store your phone number.
-              p.lead.lh-180(style="font-size:24px;")
+              p.lead.lh-180
                 |Any information provided is encrypted and used only to keep you informed.
 
   .container-fluid.w-100.p-0.mb-0(style="background-color:#65C6E1;")

--- a/src/templates/pages/testingsite_landing.pug
+++ b/src/templates/pages/testingsite_landing.pug
@@ -14,12 +14,12 @@
 
     .row.m-2.mb-md-5
       .col-lg-6.col-12.pr-lg-5
-        p.h1.lh-180.mb-3(style="font-size:30px;")
+        h3.h1.lh-180.mb-3
           | Zerobase is a free, HIPAA/GDPR-compliant contact tracing platform that helps healthcare providers, local officials, and individuals contain and eliminate COVID-19.
       .col-lg-6.col-12
-        p.lead.lh-180(style="font-size:24px;")
+        p.lead.lh-180
           | Providers who administer COVID-19 tests can deploy Zerobase with nothing more than paper printouts.
-        p.lead.lh-180(style="font-size:24px;")
+        p.lead.lh-180
           | Because of this, Zerobase can be used at any freestanding, mobile, and temporary testing site.
 
     .container
@@ -28,7 +28,7 @@
           .media-container-row
             .media-content
               .mbr-section-text
-                p.mbr-text.mb-0.mbr-fonts-style(style="font-size:24px;")
+                p.mbr-text.mb-0.mbr-fonts-style
                   strong Our contact tracing platform monitors
                   |     the spread of the virus throughout a community and can provide individualized risk exposure scores, allowing providers to deploy scarce testing and protective resources most efficiently.
 
@@ -38,50 +38,51 @@
           .media-container-row
             .media-content
               .mbr-section-text
-                p.mbr-text.mb-0.mbr-fonts-style(style="font-size:24px;")
+                p.mbr-text.mb-0.mbr-fonts-style
                   strong Unlike other contact tracing mechanisms
                   |     developed so far, Zerobase does not track GPS locations, require downloading an app, or necessitate installing intrusive technology.
 
 
       .container.mt-6
          .row.m-4.p-5.mt-5.border-top.border-secondary.pb-4.pt-4
-            .col-12(style="font-size:48px;")
-                strong Here's how it works:
+            .col-12
+                h3.h1.lh-180.mb-3
+                    strong Here's how it works:
 
          .row.align-middle
             .col-lg-3.col-3.text-center
-                p(style="font-size:76px;")
+                p(style="font-size:60px;")
                   strong 1
 
             .col-lg-9.col-9.align-middle.my-auto
-                p.align-middle(style="font-size:24px;")
+                p.align-middle
                     | Upon intake, each patient tested for COVID-19 is given a sheet of paper with a Zerobase QR code on it to scan. Each code sheet is unique and anonymous. Batches of code sheets can be printed and used at testing centers or distributed to mobile or temporary sites.
 
          .row.align-middle
             .col-lg-3.col-3.text-center
-                p(style="font-size:76px;")
+                p(style="font-size:60px;")
                   strong 2
 
             .col-lg-9.col-9.align-middle.my-auto
-                p.align-middle(style="font-size:24px;")
+                p.align-middle
                     | Using the patient’s trace history, Zerobase’s technology anonymously analyzes community networks of interaction to calculate a risk score for the patient based on their check-in history.
 
          .row.align-middle
             .col-lg-3.col-3.text-center
-                p(style="font-size:76px;")
+                p(style="font-size:60px;")
                   strong 3
 
             .col-lg-9.col-9.align-middle.my-auto
-                p.align-middle(style="font-size:24px;")
+                p.align-middle
                     | Tracing and test results will be combined to identify individuals in a community who visited the same places as the patient around the same time.
 
          .row.align-middle
             .col-lg-3.col-3.text-center
-                p(style="font-size:76px;")
+                p(style="font-size:60px;")
                   strong 4
 
             .col-lg-9.col-9.align-middle.my-auto
-                p.align-middle(style="font-size:24px;")
+                p.align-middle
                     | Public health officials can then notify individuals who are registered for contact who may have been exposed and advise them to self-quarantine or get tested, even before they exhibit symptoms.
 
 
@@ -91,22 +92,23 @@
           .media-container-row
             .media-content
               .mbr-section-text
-                p.mbr-text.mb-0.mbr-fonts-style(style="font-size:24px;")
+                h3.mbr-text.mb-0.mbr-fonts-style
                   strong Our team will work closely with you to ensure a smooth rollout in your facilities.
+                p.mbr-text.mb-0.mbr-fonts-style
                   |     Zerobase is designed to support our vital healthcare partners and help them stay safe as they provide the critical emergency care that our communities depend on.
       br
       br
       .container
         .row.m-4.p-5.mt-5.border-top.border-secondary.pb-4.pt-4
             .col-lg-8.col-12.pr-lg-5.mt-6
-                p.h1.lh-180.mb-3(style="font-size:24px;")
+                h1.lh-180.mb-3
                    | Support your community in the fight against COVID-19.
-                p.h2.font-weight-normal
+                h2.font-weight-normal
                    |Zerobase is free, it’s ready, and it saves lives.
 
             .col-lg-4.col-12.align-middle.mt-6
 
-                router-link.btn.btn-primary.btn-lg.align-middle(to='/healthcare/register', id='register-healthcare') 
+                router-link.btn.btn-primary.btn-lg.align-middle(to='/healthcare/register', id='register-healthcare')
                   | Register your site
 
 

--- a/src/templates/pages/volunteer_landing.pug
+++ b/src/templates/pages/volunteer_landing.pug
@@ -15,113 +15,117 @@
 
     .row.m-2.mb-md-5
         .col-lg-12.col-12
-          p.lead.lh-180(style="font-size:24px;")
-            | We are a free, privacy-first contact tracing platform that empowers both individuals and local officials to stop the spread of COVID-19 in a way that is private, easy to use, and helps to alleviate the manual issues involved in contact tracing and individualized testing. To learn more about zerobase and the importance of tracing, read our 
+          p.lead.lh-180
+            | We are a free, privacy-first contact tracing platform that empowers both individuals and local officials to stop the spread of COVID-19 in a way that is private, easy to use, and helps to alleviate the manual issues involved in contact tracing and individualized testing. To learn more about zerobase and the importance of tracing, read our
             router-link.text-wrap(to='/about') about page.
 
   .container.px-4
      hr
      .row.mt-5
-        .col-12.text-center(style="font-size:30px;")
-          strong Thank you for your interest in volunteering!
-          br
-          | We are excited to have you!
+        .col-12.text-center
+            h2
+                strong Thank you for your interest in volunteering!
+                br
+                | We are excited to have you!
 
      .row.mt-5.text-center.mb-5
-        .col-md-6.col-12(style="font-size:24px;")
+        .col-md-6.col-12.text-center
             strong 1. Fill out our our volunteer form
             br
             a.btn.btn-lg.btn-dark.my-2(href="https://docs.google.com/forms/d/e/1FAIpQLSenbQaMHQTFyULEz7etYqM6X9sckrRwggbD5RMFqNpKT5AR4w/viewform" , target="_blank")
                 Zerobase Registration Form
 
-        .col-md-6.col-12(style="font-size:24px;").text-center
+        .col-md-6.col-12.text-center
             strong 2. Join our slack
             br
             a.btn.btn-lg.btn-dark.my-2(href="https://join.slack.com/t/necsi-edu/shared_invite/zt-d86ge6g0-sgLKgyhRpFBJq2VrnJOdhg" , target="_blank")
                 | Zerobase Slack
      hr
      .row.mt-5.pb-4
-        .col-12.text-center(style="font-size:30px;")
-            strong Join a team! Here are some channels to get you started:
+        .col-12.text-center
+            h2
+                strong Join a team! Here are some channels to get you started:
 
      .row.mt-5.mb-3.text-center
         .col-md-6.col-12
             a(href="https://necsi-edu.slack.com/archives/CV57RBU8H")
-                p(style="font-size:24px;")
+                p
                     strong #zerobase-general
         .col-md-6.col-12
-            p.align-middle(style="font-size:24px;")
+            p.align-middle
                 | Our main channel
 
      .row.mt-5.text-center
         .col-md-6.col-12
          a(href="https://necsi-edu.slack.com/archives/CV82ELK26")
-            p(style="font-size:24px;")
+            p
               strong #zerobase-backend
 
         .col-md-6.col-12
-            p.align-middle(style="font-size:24px;")
+            p.align-middle
                 | For backend developers
 
      .row.mt-5.text-center
         .col-md-6.col-12
             a(href="https://necsi-edu.slack.com/archives/C010MA2D7PU")
-                p(style="font-size:24px;")
+                p
                   strong #zerobase-deployments
 
         .col-md-6.col-12
-            p.align-middle(style="font-size:24px;")
+            p.align-middle
                 | For deployments in the real world
 
      .row.mt-5.text-center
         .col-md-6.col-12
             a(href="https://necsi-edu.slack.com/archives/C010DL0BXKR")
-                p(style="font-size:24px;")
+                p
                   strong #zerobase-frontend
 
         .col-md-6.col-12
-            p.align-middle(style="font-size:24px;")
+            p.align-middle
                 | For frontend developers, UX, and Medical
 
      .row.mt-5.text-center
         .col-md-6.col-12
             a(href="https://necsi-edu.slack.com/archives/CV9UKU1HR")
-                p(style="font-size:24px;")
+                p
                   strong #zerobase-infra
 
         .col-md-6.col-12
-            p.align-middle(style="font-size:24px;")
+            p.align-middle
                 | For infrastructure and DevSecOps
 
      .row.mt-5.text-center
         .col-md-6.col-12
             a(href="https://necsi-edu.slack.com/archives/C0105T4K0F2")
-                p(style="font-size:24px;")
+                p
                   strong #zerobase-product
 
         .col-md-6.col-12
-            p.align-middle(style="font-size:24px;")
+            p.align-middle
                 | For product development
      hr
      .row.mt-5.pb-4
-         .col-12.text-center(style="font-size:30px;")
-             strong Check out our GitHub!
+         .col-12.text-center
+             h2
+                strong Check out our GitHub!
              br
              a.btn.btn-lg.btn-dark(href="https://github.com/zerobase-io/About-Us-Onboarding", target="_blank")
                 | Zerobase GitHub
      .row.mt-5.pb-4
-         .col-12(style="font-size:30px;")
-             strong Any questions? Get stuck?
+         .col-12
+             h2
+                strong Any questions? Get stuck?
              .form-inline
-                 p(style="font-size:24px;")
+                 p
                     | Email us at &nbsp;
                  a.text-nowrap(href="mailto://info@zerobase.io")
-                    p(style="font-size:24px;")
+                    p
                         strong info@zerobase.io &nbsp;
-                 p(style="font-size:24px;")
+                 p
                     | or ask in &nbsp;
                  a(href="https://necsi-edu.slack.com/archives/C010FSAKGPQ")
-                    p(style="font-size:24px;")
+                    p
                       strong #zerobase-volunteers
 
 


### PR DESCRIPTION
Removed explicit font sized and changed to default header and paragraph tags. Numbered lists in individuals_landing and testingsite_landing have been resized slightly smaller to fit the sizing better, but should probably have their styling moved out to public/overrides.css. Tested on edge, chrome, and firefox default resolutions, and chrome at mobile resolution.